### PR TITLE
Make Flags::flags and Platform::platform optional

### DIFF
--- a/src/payload.rs
+++ b/src/payload.rs
@@ -83,8 +83,8 @@ pub struct ChannelOptionsUpdate {
 pub struct Flags {
     /// User ID whose flags changed.
     pub user_id: UserId,
-    /// Flags bitfield.
-    pub flags: u32,
+    /// Flags bitfield. Is None for bot users.
+    pub flags: Option<u32>,
 }
 
 /// Platform information for a user.
@@ -92,8 +92,9 @@ pub struct Flags {
 pub struct Platform {
     /// User ID.
     pub user_id: UserId,
-    /// Platform code (0 = desktop, 1 = mobile, 2 = web, etc.).
-    pub platform: u32,
+    /// Platform code (0 = desktop, 1 = mobile, 2 = web, etc.). Is None for
+    /// bot users.
+    pub platform: Option<u32>,
 }
 
 /// Used to keep the websocket connection alive.


### PR DESCRIPTION
They are `null` for bot users.